### PR TITLE
Add OpenShift Imagestream

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,13 @@ build an image tagged as `image-name`
 
 - `SBT_SUBPROJECT`; optional string that specifies the sbt subproject to build in (not needed if not multi-project)
 - `plugins.sbt`; contains default set of sbt plugins that will be cached during the image build
+
+### OpenShift Imagestream
+
+An OpenShift Imagestream is provided that can be used in the OpenSHift console to build applications using this s2i image. To use it, simply add it as follows:
+
+```
+oc create -f sbt.yml
+```
+
+Note the openshift user must have rights to the openshift namespace (i.e. a cluster admin).

--- a/sbt.yml
+++ b/sbt.yml
@@ -1,0 +1,50 @@
+apiVersion: v1
+kind: ImageStream
+metadata:
+  annotations:
+    description: Build and run Scala and Java applications using SBT
+    iconClass: icon-scala
+    openshift.io/display-name: SBT
+    openshift.io/image.dockerRepositoryCheck: 2017-12-08T19:01:11Z
+    eationTimestamp: 2017-12-08T18:32:08Z
+  generation: 4
+  name: sbt
+  namespace: openshift
+spec:
+  lookupPolicy:
+    local: false
+  tags:
+  - annotations:
+      description: Build and run Scala and Java applications using SBT
+      iconClass: icon-scala
+      openshift.io/display-name: SBT
+      openshift.io/provider-display-name: Demo
+      sampleRepo: https://github.com/theiterators/akka-http-microservice
+      supports: sbt:0.13.15,java,scala
+      tags: builder,java,scala
+      version: "0.13.15"
+    from:
+      kind: DockerImage
+      name: jwiii/sbt-s2i:0.13.15-2.12.3
+    generation: 1
+    importPolicy: {}
+    name: "0.13.15"
+    referencePolicy:
+      type: Source
+  - annotations:
+      description: Build and run Scala and Java applications using SBT 0.13
+      iconClass: icon-scala
+      openshift.io/display-name: SBT
+      openshift.io/provider-display-name: Demo
+      sampleRepo: https://github.com/theiterators/akka-http-microservice
+      supports: sbt:0.13.16,java,scala
+      tags: builder,java,scala
+      version: "0.13.16"
+    from:
+      kind: DockerImage
+      name: jwiii/sbt-s2i:0.13.16-2.12.3
+    generation: 1
+    importPolicy: {}
+    name: "0.13.16"
+    referencePolicy:
+      type: Source

--- a/sbt.yml
+++ b/sbt.yml
@@ -5,8 +5,6 @@ metadata:
     description: Build and run Scala and Java applications using SBT
     iconClass: icon-scala
     openshift.io/display-name: SBT
-    openshift.io/image.dockerRepositoryCheck: 2017-12-08T19:01:11Z
-    eationTimestamp: 2017-12-08T18:32:08Z
   generation: 4
   name: sbt
   namespace: openshift
@@ -18,7 +16,7 @@ spec:
       description: Build and run Scala and Java applications using SBT
       iconClass: icon-scala
       openshift.io/display-name: SBT
-      openshift.io/provider-display-name: Demo
+      openshift.io/provider-display-name: https://github.com/jw3/sbt-s2i
       sampleRepo: https://github.com/theiterators/akka-http-microservice
       supports: sbt:0.13.15,java,scala
       tags: builder,java,scala
@@ -35,7 +33,7 @@ spec:
       description: Build and run Scala and Java applications using SBT 0.13
       iconClass: icon-scala
       openshift.io/display-name: SBT
-      openshift.io/provider-display-name: Demo
+      openshift.io/provider-display-name: https://github.com/jw3/sbt-s2i
       sampleRepo: https://github.com/theiterators/akka-http-microservice
       supports: sbt:0.13.16,java,scala
       tags: builder,java,scala


### PR DESCRIPTION
This adds an OpenShift Imagestream that pulls your images from docker hub.

It would be great if you could add tags for ```0.13.15``` and ```0.13.16``` in addition to the detailed version tag. This way the imagestream would always be picking up the latest version.